### PR TITLE
chore: add concurrency rules to workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,14 +15,12 @@ body:
       label: Guide you're having trouble with
       description: If this feature is related to a specific guide, please provide the link to the guide.
       placeholder: https://code.community.com/guides/the-guide
-      value: ""
   - type: textarea
     id: what-happened
     attributes:
       label: What happened?
       description: Also tell us, what did you expect to happen?
       placeholder: Tell us what you see!
-      value: ""
     validations:
       required: true
   - type: textarea
@@ -30,7 +28,6 @@ body:
     attributes:
       label: What did you expect to happen?
       placeholder: Tell us what you expected!
-      value: ""
   - type: textarea
     id: environment
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,7 +3,7 @@ description: File a bug report.
 title: "[Bug]: "
 labels: ["bug", "triage"]
 assignees:
-  - @zkSync-Community-Hub/zksync-devrel
+  - zkSync-Community-Hub/zksync-devrel
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -15,14 +15,12 @@ body:
       label: Description
       description: Please provide a brief description of the feature you would like to see.
       placeholder: Tell us what you would like to see!
-      value: ""
   - type: textarea
     id: rationale
     attributes:
       label: Rationale
       description: Why do you think this feature would be beneficial to the community?
       placeholder: Tell us why you think this feature would be beneficial!
-      value: ""
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,7 +3,7 @@ description: Is there a feature you would like to see in Code Community? Let us 
 title: "[Feature]: "
 labels: ["feature", "triage"]
 assignees:
-  - @zkSync-Community-Hub/zksync-devrel
+  - zkSync-Community-Hub/zksync-devrel
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/new_guide_request.yml
+++ b/.github/ISSUE_TEMPLATE/new_guide_request.yml
@@ -15,7 +15,6 @@ body:
       label: Description
       description: Please provide a brief description of the guide you would like to see.
       placeholder: Tell us what you would like to see!
-      value: ""
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/new_guide_request.yml
+++ b/.github/ISSUE_TEMPLATE/new_guide_request.yml
@@ -3,7 +3,7 @@ description: Use this form to request a guide you would like to see in Code Comm
 title: "[Guide]: "
 labels: ["guide", "triage"]
 assignees:
-  - @zkSync-Community-Hub/zksync-devrel
+  - zkSync-Community-Hub/zksync-devrel
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -7,6 +7,10 @@ env:
   HUSKY: 0
   CI: true
 
+concurrency:
+  group: production
+  cancel-in-progress: true
+
 jobs:
   build_and_deploy:
     env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -9,6 +9,10 @@ env:
   HUSKY: 0
   CI: true
 
+concurrency:
+  group: staging
+  cancel-in-progress: true
+
 jobs:
   build_and_deploy:
     env:


### PR DESCRIPTION
# Description

Add concurrency rules to workflows for staging and production deploy workflows. This cancels any currently running workflow when a new workflow is set to run. For example when two PRs are merged to main around the same time, one will cancel out the other and only one workflow is run to deploy.
This makes it so that we don't have a queue of build and deploys to run, cutting down time and resources.

Fix yaml formatting errors with github issue templates. They do not list in Create Issues if format is incorrect.