### PR TITLE
chore: fix deploy target for prod

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_COMMUNITY_COOKBOOK_59807 }}"
-          target: prod
           projectId: community-cookbook-59807
           channelId: live
 


### PR DESCRIPTION

# Description

Remove `target` for prod deploy workflow. This tries to search for a target defined in `firebase.json`. We don't have any targets defined since our configuration shouldn't be any different for staging and prod deploys.