### PR TITLE
chore: add rule for commit-analyzer

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -5,7 +5,18 @@
   "addReleases": "top",
   "npmPublish": false,
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          {
+            "type": "docs",
+            "release": "minor"
+          }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/github"
   ]


### PR DESCRIPTION
# Description

Add rule for commit-analyzer to identify `docs` tags for commits as minor releases.