### PR TITLE
fix: use getGeneralPaymasterInput instead of zksync-ethers for viem paymasters

### DIFF
--- a/content/tutorials/guide-viem/10.index.md
+++ b/content/tutorials/guide-viem/10.index.md
@@ -99,7 +99,7 @@ To utilize ZKsync Era's native account abstraction and Paymasters, extend the Wa
 import 'viem/window';
 import { createWalletClient, custom } from 'viem';
 import { zkSync } from 'viem/chains';
-import { eip712WalletActions } from 'viem/zksync';
+import { eip712WalletActions, getGeneralPaymasterInput } from 'viem/zksync';
 
 // Initialize and extend the wallet client
 const walletClient = createWalletClient({
@@ -111,13 +111,7 @@ const walletClient = createWalletClient({
 #### Sending a Transaction with a Paymaster
 
 ```javascript
-import { utils } from "zksync-ethers";
-
 const paymasterAddress = "<DEPLOYED_PAYMASTER_ADDRESS>"; // Replace with your paymaster address
-const params = utils.getPaymasterParams(paymasterAddress, {
-  type: "General",
-  innerInput: new Uint8Array(),
-});
 
 // Send the transaction example
 const hash = await walletClient.sendTransaction({
@@ -125,7 +119,7 @@ const hash = await walletClient.sendTransaction({
   to: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
   value: 1000000000000000000n,
   paymaster: paymasterAddress,
-  paymasterInput: params.paymasterInput,
+  paymasterInput: getGeneralPaymasterInput({ innerInput: new Uint8Array() }),
 });
 ```
 
@@ -141,15 +135,7 @@ Remember to replace `PAYMASTER_CONTRACT_ADDRESS` with your own!
 #### Contract Function Call
 
 ```javascript
-import { utils } from "zksync-ethers";
-
 const paymasterAddress = "<DEPLOYED_PAYMASTER_ADDRESS>"; // Replace with actual address
-
-// Set up paymaster parameters
-const params = utils.getPaymasterParams(paymasterAddress, {
-  type: "General",
-  innerInput: new Uint8Array(),
-});
 
 // Call the contract function
 const hash = await walletClient.writeContract({
@@ -158,7 +144,7 @@ const hash = await walletClient.writeContract({
   functionName: "setGreeting",
   args: ["ZKsync!"],
   paymaster: paymasterAddress,
-  paymasterInput: params.paymasterInput,
+  paymasterInput: getGeneralPaymasterInput({ innerInput: new Uint8Array() }),
 });
 ```
 


### PR DESCRIPTION
# Description

`viem` provides `getGeneralPaymasterInput`, no need to use ethers. 
