### PR TITLE
fix: L2 to L1 tutorial - check the proof output

### DIFF
--- a/content/tutorials/how-to-send-l2-l1-message/10.index.md
+++ b/content/tutorials/how-to-send-l2-l1-message/10.index.md
@@ -334,7 +334,13 @@ Create a `4.prove-inclusion.ts` file in the root directory with the next script:
     // The full proof object, including root, proof and id
     const PROOF = {};
 
-    proveL2MessageInclusion(L1_BATCH_NUMBER, PROOF, L1_BATCH_TX_INDEX, SENDER, MESSAGE);
+    proveL2MessageInclusion(L1_BATCH_NUMBER, PROOF, L1_BATCH_TX_INDEX, SENDER, MESSAGE).then(result => {
+        if (result == true) {
+            console.log("\x1b[32mThe proof is valid\x1b[0m");
+        } else {
+            console.log("\x1b[31mThe proof is not valid\x1b[0m");
+        }
+    });
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
# Description

Actually verify the proof inclusion response and print it to the console in the tutorial.

(before, if the proof was not correct - the script still finished successfully without any warning)
