### PR TITLE
fix: custom zk chain scripts

### DIFF
--- a/code/custom-zk-chain/scripts/depositBaseToken.ts
+++ b/code/custom-zk-chain/scripts/depositBaseToken.ts
@@ -1,7 +1,12 @@
-import { ethers } from 'hardhat';
+import { ethers, network } from 'hardhat';
+import { Wallet, Provider } from 'zksync-ethers';
 
 async function main() {
-  const [wallet] = await ethers.getWallets();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const config = network.config as any;
+  const l1Provider = new Provider(config.ethNetwork);
+  const l2Provider = new Provider(config.url);
+  const wallet = new Wallet(process.env.WALLET_PRIVATE_KEY!, l2Provider, l1Provider);
   const initialBalance = await wallet.getBalance();
   console.log('INITIAL L2 Base Token Balance 🎉:', ethers.formatEther(initialBalance));
 

--- a/code/custom-zk-chain/scripts/depositETH.ts
+++ b/code/custom-zk-chain/scripts/depositETH.ts
@@ -1,8 +1,12 @@
-import { ethers } from 'hardhat';
-import { utils } from 'zksync-ethers';
+import { ethers, network } from 'hardhat';
+import { utils, Wallet, Provider } from 'zksync-ethers';
 
 async function main() {
-  const [wallet] = await ethers.getWallets();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const config = network.config as any;
+  const l1Provider = new Provider(config.ethNetwork);
+  const l2Provider = new Provider(config.url);
+  const wallet = new Wallet(process.env.WALLET_PRIVATE_KEY!, l2Provider, l1Provider);
   const l2ETHAddress = await wallet.l2TokenAddress(utils.ETH_ADDRESS_IN_CONTRACTS);
   console.log('L2 ETH Address:', l2ETHAddress);
 

--- a/content/tutorials/custom-zk-chain/10.index.md
+++ b/content/tutorials/custom-zk-chain/10.index.md
@@ -98,10 +98,7 @@ If you choose different names for your ecosystem or chain, remember to update th
 │  Eth
 │
 ◇  Enable EVM emulator?
-│  No
-│
-◇  Enable EVM emulator?
-│  No
+│  Yes
 │
 ◇  Do you want to start containers after creating the ecosystem?
 │  Yes
@@ -127,7 +124,7 @@ By running this command and selecting these options, you just:
     You can read more about data availability options for ZKsync Chains in the
     [ZKsync Chains](https://docs.zksync.io/zk-stack/concepts/zk-chains#data-availability-da) docs.
 - Selected ETH to use as the base token.
-- Selected to not use the EVM Emulator.
+- Selected to enable the EVM Emulator, which allows EVM bytecode to be deployed.
 - Started the containers for the ecosystem in Docker.
 
 Inside the generated `my_elastic_network` folder, you should now have the following contents:
@@ -225,7 +222,8 @@ The [Portal](https://github.com/matter-labs/dapp-portal) module is a web app tha
 - View balances.
 - Add contacts for quick and easy access.
 
-Once you have at least one chain initialized, you can run the portal app locally:
+Once you have at least one chain initialized, you can run the portal app locally.
+Open a new terminal in your ecosystem folder and run:
 
 ```bash
 zkstack portal
@@ -242,25 +240,29 @@ You can now navigate to the portal web app. By default, the portal frontend star
 A block explorer is a web-app that lets you view and inspect transactions, blocks,
 contracts and more. A [free open source block explorer](https://github.com/matter-labs/block-explorer) is available for your ZKsync Chain.
 
-First, each chain should be initialized:
+First, each chain should be initialized.
+To initialize your chain,
+open a new terminal in your ecosystem folder and run:
 
 ```bash
 zkstack explorer init
 ```
 
+You can select the default options for the prompts.
 This command creates a database to store explorer data and generates a docker compose file with explorer services
 (`explorer-docker-compose.yml`).
 
 Next, for each chain you want to have an explorer, you need to start its backend services:
 
 ```bash
-zkstack explorer backend --chain <chain_name>
+zkstack explorer backend --chain zk_chain_1
 ```
 
 This command uses the previously created docker compose file to start the services (api, data fetcher, worker) required for
 the explorer.
 
-Finally, you can run the explorer app:
+Finally, you can run the explorer app.
+Open another terminal in your ecosystem folder and run:
 
 ```bash
 zkstack explorer run
@@ -283,20 +285,13 @@ You can find a full list of rich wallet addresses and their private keys in the 
 Never use these wallets in production or send real funds to them.
 ::
 
-Open a new terminal and run the command below to bridge some ETH to `zk_chain_1` using ZKsync CLI:
+Open a new terminal in your ecosystem folder and run the command below to bridge some ETH to `zk_chain_1`.
+This command will bridge 1 ETH to `0x36615cf349d7f6344891b1e7ca7c72883f5dc049`.
 
 :test-action{actionId="deposit-eth"}
 
 ```bash
-npx zksync-cli bridge deposit --rpc=http://localhost:3050 --l1-rpc=http://localhost:8545
-```
-
-For testing purposes, we'll use one of the rich wallets as both the sender and recipient:
-
-```shell
-? Amount to deposit 10
-? Private key of the sender 0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110
-? Recipient address on L2 0x36615Cf349d7F6344891B1e7CA7C72883F5dc049
+zkstack dev rich-account --chain zk_chain_1
 ```
 
 To see that it worked, let's check the balance of that address on `zk_chain_1`:

--- a/content/tutorials/custom-zk-chain/20.customizing-your-chain.md
+++ b/content/tutorials/custom-zk-chain/20.customizing-your-chain.md
@@ -117,7 +117,7 @@ you can add the `WALLET_PRIVATE_KEY` environment variable:
 :test-action{actionId="new-env"}
 
 ```bash
-# Use the private key of the `governor` from configs/wallets.yaml
+# Use the private key of the `governor` from my_elastic_network/configs/wallets.yaml
 WALLET_PRIVATE_KEY=<governor_private_key_from_configs_wallets.yaml>
 ```
 
@@ -263,7 +263,7 @@ This time, use the answers below:
 │  1
 │
 ◇  Enable EVM emulator?
-│  No
+│  Yes
 │
 ◇  Set this chain as default?
 │  Yes

--- a/tests/configs/custom-zk-chain.ts
+++ b/tests/configs/custom-zk-chain.ts
@@ -46,8 +46,6 @@ const partOneSteps: IStepConfig = {
   'deposit-eth': {
     action: 'runCommand',
     commandFolder: 'tests-output/custom-zk-chain/my_elastic_network',
-    prompts:
-      'Amount to deposit:9|Private key of the sender:0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110|Recipient address on L2:',
   },
   'check-balance': {
     action: 'runCommand',


### PR DESCRIPTION
fixes for zk chain tutorial:

- replace `getWallets` method
- use `rich-accounts` method instead of `zksync-cli`
- enable EVM interpreter
- small clarifications